### PR TITLE
[#17385] update formatting and syntax for python 3

### DIFF
--- a/pyramid_mustache/__init__.py
+++ b/pyramid_mustache/__init__.py
@@ -1,8 +1,8 @@
-from pystache.context   import ContextStack
-from pystache           import Renderer
-from pyramid.path       import AssetResolver
-from pyramid.i18n       import get_localizer
-from pyramid.i18n       import TranslationStringFactory
+from pystache.context import ContextStack
+from pystache import Renderer
+from pyramid.path import AssetResolver
+from pyramid.i18n import get_localizer
+from pyramid.i18n import TranslationStringFactory
 
 import re
 import os.path
@@ -18,20 +18,24 @@ from pyramid.settings import (
 class LexRenderer(Renderer):
     """Deal with ES results of the form '["5925074"]' which from python ends up
        as %5Bu'5925074'%5D  """
+
     def str_coerce(self, val):
         if isinstance(val, list):
             if len(val) == 1:
                 return ''.join(val)
             else:
-                raise ValueError("Lists like %s should iterated and not rendered at once", val)
+                raise ValueError(
+                    "Lists like %s should iterated and not rendered at once", val)
         else:
-	    return unicode(val)
+            return unicode(val)
 
 
 def includeme(config):
     config.add_renderer('.mustache', MustacheRendererFactory)
 
+
 _ = TranslationStringFactory('pyramid_mustache')
+
 
 class MustacheContextStack(ContextStack):
     """ Context stack that makes renderering match with mustache.js """
@@ -44,10 +48,12 @@ class MustacheContextStack(ContextStack):
         else:
             return value
 
+
 class MustacheRendererFactory(object):
     def __init__(self, info):
         self.info = info
-        self.mustache_directories = self.info.settings.get('mustache.directories')
+        self.mustache_directories = self.info.settings.get(
+            'mustache.directories')
         if not is_nonstr_iter(self.mustache_directories):
             self.mustache_directories = aslist(
                 self.mustache_directories or '',
@@ -113,7 +119,8 @@ class MustacheRendererFactory(object):
         template_stream = template_fh.read()
         template_fh.close()
 
-        mustache_directories = self.mustache_directories or [os.path.dirname(full_path)]
+        mustache_directories = self.mustache_directories or [
+            os.path.dirname(full_path)]
         partials = PartialsLoader(mustache_directories, ar)
 
         renderer = LexRenderer(partials=partials, string_encoding='utf8')
@@ -130,6 +137,7 @@ class MustacheRendererFactory(object):
 
         return self.render_template(self.info.name)
 
+
 class PartialsLoader(object):
     def __init__(self, partials_roots, asset_resolver):
         self.partials_roots = partials_roots
@@ -141,7 +149,8 @@ class PartialsLoader(object):
             self.partials[key] = None
             partial_filename = key + '.mustache'
             for partials_root in self.partials_roots:
-                partials_root = self.asset_resolver.resolve(partials_root).abspath()
+                partials_root = self.asset_resolver.resolve(
+                    partials_root).abspath()
                 for dirpath, dirnames, filenames in os.walk(partials_root):
                     for filename in filenames:
                         if filename == partial_filename:

--- a/pyramid_mustache/tests/test_mustache.py
+++ b/pyramid_mustache/tests/test_mustache.py
@@ -6,7 +6,7 @@ from pyramid_mustache import (
 import pystache
 from pystache import Renderer
 
-our_template=u"""{{#Patent}}
+our_template = u"""{{#Patent}}
        <h4>
          <a href="/patent/{{link_number}}">
            <span class="label label-patent-big">{{link_number}}</span>
@@ -15,7 +15,7 @@ our_template=u"""{{#Patent}}
        </h4>
  {{/Patent}}"""
 
-our_other_template=u"""{{#Patent}}
+our_other_template = u"""{{#Patent}}
        <h4>
          {{#link_number}}
          <a href="/patent/{{.}}">
@@ -32,20 +32,22 @@ class TestMustache(TestCase):
 
     def test_mustache_default(self):
         renderer = Renderer()
-        output = renderer.render(our_template, {'Patent':{'title':'foo-bar','link_number':[u'1234']}})
+        output = renderer.render(
+            our_template, {'Patent': {'title': 'foo-bar', 'link_number': [u'1234']}})
         print 'default output %s', output
         self.assertIn('[u', output)
 
-
     def test_mustache_lex(self):
         renderer = LexRenderer()
-        output = renderer.render(our_template, {'Patent':{'title':'foo-bar','link_number':[u'1234']}})
+        output = renderer.render(
+            our_template, {'Patent': {'title': 'foo-bar', 'link_number': [u'1234']}})
         print 'output %s', output
         self.assertNotIn('[u', output)
 
     def test_mustache_lex_string(self):
         renderer = LexRenderer()
-        output = renderer.render(our_template, {'Patent':[{'title':['foo-bar','baz'],'link_number': u'1234'}, {'title':'Balloons','link_number': u'999999'}]})
+        output = renderer.render(our_template, {'Patent': [{'title': [
+                                 'foo-bar', 'baz'], 'link_number': u'1234'}, {'title': 'Balloons', 'link_number': u'999999'}]})
         print 'output %s', output
         self.assertIn('1234', output)
         self.assertNotIn('[u', output)
@@ -53,21 +55,23 @@ class TestMustache(TestCase):
     def test_mustache_lex_list_error(self):
         renderer = LexRenderer()
         with self.assertRaises(ValueError):
-            renderer.render(our_template, {'Patent':{'title':'foo-bar','link_number':[u'1234',u'5678']}})
+            renderer.render(our_template, {'Patent': {
+                            'title': 'foo-bar', 'link_number': [u'1234', u'5678']}})
 
     def test_mustache_lex_list_success(self):
         renderer = LexRenderer()
-        output= renderer.render(our_other_template, {'Patent':{'title':'foo-bar','link_number':[u'1234',u'5678']}})
+        output = renderer.render(our_other_template, {'Patent': {
+                                 'title': 'foo-bar', 'link_number': [u'1234', u'5678']}})
         print 'output %s', output
         self.assertIn('1234', output)
         self.assertIn('5678', output)
-        self.assertNotIn('[u',output)
-    
+        self.assertNotIn('[u', output)
+
     def test_mustache_lex_integer(self):
         renderer = LexRenderer()
-        output= renderer.render(our_other_template, {'Patent':{'title':'foo-bar','link_number':[1234], 'numRows': 10}})
+        output = renderer.render(our_other_template, {'Patent': {
+                                 'title': 'foo-bar', 'link_number': [1234], 'numRows': 10}})
         print 'output %s', output
         self.assertIn('1234', output)
         self.assertIn('10', output)
-        self.assertNotIn('[u',output)
-
+        self.assertNotIn('[u', output)


### PR DESCRIPTION
Some autopep8 format fixes to solve a python3 error:
```
======================================================================
ERROR: test suite for <module 'lexdb.tests.functional' from '/home/jeff/lexmachina/deus_lex/lexdb/lexdb/tests/functional/__init__.py'>
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/jeff/lexmachina/deus_lex/.tox/py36/lib/python3.6/site-packages/nose/suite.py", line 210, in run
    self.setUp()
  File "/home/jeff/lexmachina/deus_lex/.tox/py36/lib/python3.6/site-packages/nose/suite.py", line 293, in setUp
    self.setupContext(ancestor)
  File "/home/jeff/lexmachina/deus_lex/.tox/py36/lib/python3.6/site-packages/nose/suite.py", line 316, in setupContext
    try_run(context, names)
  File "/home/jeff/lexmachina/deus_lex/.tox/py36/lib/python3.6/site-packages/nose/util.py", line 471, in try_run
    return func()
  File "/home/jeff/lexmachina/deus_lex/lexdb/lexdb/tests/functional/__init__.py", line 46, in setup_package
    from bias.tests import make_database
  File "/home/jeff/lexmachina/deus_lex/bias/bias/tests/__init__.py", line 8, in <module>
    from bias.tasks.normalizer.normalize_parties import (
  File "/home/jeff/lexmachina/deus_lex/bias/bias/tasks/__init__.py", line 64, in <module>
    from bias.tasks.alerting import (
  File "/home/jeff/lexmachina/deus_lex/bias/bias/tasks/alerting.py", line 22, in <module>
    from bias.configs.production import (
  File "/home/jeff/lexmachina/deus_lex/bias/bias/configs/production.py", line 7, in <module>
    from .base import *
  File "/home/jeff/lexmachina/deus_lex/bias/bias/configs/base.py", line 141, in <module>
    os.path.dirname(os.path.abspath(importlib.import_module('bias.templates').__file__)),
  File "/home/jeff/lexmachina/deus_lex/.tox/py36/lib/python3.6/importlib/__init__.py", line 126, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "/home/jeff/lexmachina/deus_lex/bias/bias/templates/__init__.py", line 4, in <module>
    from pyramid_mustache import MustacheRendererFactory
  File "/home/jeff/lexmachina/deus_lex/vendor/pyramid-mustache/pyramid_mustache/__init__.py", line 28
    return unicode(val)
                      ^
TabError: inconsistent use of tabs and spaces in indentation
```