### PR TITLE
Use str() instead because unicode() is not defined in Python 3

### DIFF
--- a/pyramid_mustache/__init__.py
+++ b/pyramid_mustache/__init__.py
@@ -1,3 +1,4 @@
+from builtins import str
 from pystache.context import ContextStack
 from pystache import Renderer
 from pyramid.path import AssetResolver
@@ -27,7 +28,7 @@ class LexRenderer(Renderer):
                 raise ValueError(
                     "Lists like %s should iterated and not rendered at once", val)
         else:
-            return unicode(val)
+            return str(val)
 
 
 def includeme(config):


### PR DESCRIPTION
`unicode()` is Python2 only, so update to make compatible with Python 2 and 3. 

Discovered when trying to get to the Parties landing page and getting this error:
```
  File "/home/frances/deus_lex/vendor/pyramid-mustache/pyramid_mustache/__init__.py", line 30, in str_coerce
    return unicode(val)
NameError: name 'unicode' is not defined
```

Verified by making this change locally to `/home/frances/deus_lex/vendor/pyramid-mustache/pyramid_mustache/__init__.py`  and successfully opening the Parties landing page.